### PR TITLE
Support for docker-style environment variables on code upload

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -117,7 +117,7 @@ type UploadCmd struct {
 	zip          *string
 	codes        worker.Code // for fields, not code
 	cmd          string
-	envVars      *stringSlice
+	envVars      *envSlice
 }
 
 type QueueCmd struct {
@@ -536,14 +536,13 @@ func (u *UploadCmd) Args() error {
 	}
 
 	if *u.envVars != nil {
-		envVarsMap := make(map[string]string)
-		if envSlice, ok := u.envVars.Get().(stringSlice); ok {
-			for _, val := range envSlice {
-				pair := strings.SplitN(val, "=", 2)
-				envVarsMap[pair[0]] = pair[1]
+		if envSlice, ok := u.envVars.Get().(envSlice); ok {
+			envVarsMap := make(map[string]string, len(envSlice))
+			for _, envItem := range envSlice {
+				envVarsMap[envItem.Name] = envItem.Value
 			}
+			u.codes.EnvVars = envVarsMap
 		}
-		u.codes.EnvVars = envVarsMap
 	}
 
 	return nil

--- a/commands.go
+++ b/commands.go
@@ -117,6 +117,7 @@ type UploadCmd struct {
 	zip          *string
 	codes        worker.Code // for fields, not code
 	cmd          string
+	envVars      *stringSlice
 }
 
 type QueueCmd struct {
@@ -476,6 +477,7 @@ func (u *UploadCmd) Flags(args ...string) error {
 	u.config = u.flags.config()
 	u.configFile = u.flags.configFile()
 	u.zip = u.flags.zip()
+	u.envVars = u.flags.envVars()
 
 	err := u.flags.Parse(args)
 	if err != nil {
@@ -532,6 +534,18 @@ func (u *UploadCmd) Args() error {
 		}
 		u.codes.Config = string(pload)
 	}
+
+	if *u.envVars != nil {
+		envVarsMap := make(map[string]string)
+		if envSlice, ok := u.envVars.Get().(stringSlice); ok {
+			for _, val := range envSlice {
+				pair := strings.SplitN(val, "=", 2)
+				envVarsMap[pair[0]] = pair[1]
+			}
+		}
+		u.codes.EnvVars = envVarsMap
+	}
+
 	return nil
 }
 

--- a/flags.go
+++ b/flags.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -103,6 +104,26 @@ func (wf *WorkerFlags) zip() *string {
 
 func (wf *WorkerFlags) cluster() *string {
 	return wf.String("cluster", "", "optional: specify cluster to queue task on")
+}
+
+// -- stringSlice Value
+type stringSlice []string
+
+func (s *stringSlice) Set(val string) error {
+	*s = append(*s, val)
+	return nil
+}
+
+func (s *stringSlice) Get() interface{} {
+	return *s
+}
+
+func (s *stringSlice) String() string { return fmt.Sprintf("%v", *s) }
+
+func (wf *WorkerFlags) envVars() *stringSlice {
+	var sameNamedFlags stringSlice
+	wf.Var(&sameNamedFlags, "e", "optional: specify environment variable for your code in format 'var=value'")
+	return &sameNamedFlags
 }
 
 // TODO(reed): pretty sure there's a better way to get types from flags...

--- a/flags.go
+++ b/flags.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
+	"unicode"
 )
 
 type WorkerFlags struct {
@@ -106,23 +109,47 @@ func (wf *WorkerFlags) cluster() *string {
 	return wf.String("cluster", "", "optional: specify cluster to queue task on")
 }
 
-// -- stringSlice Value
-type stringSlice []string
-
-func (s *stringSlice) Set(val string) error {
-	*s = append(*s, val)
+func allowedSymbolsOnly(s string) error {
+	for _, runeValue := range s {
+		if !(runeValue == '/' || runeValue == '_' || runeValue == '-' || unicode.IsLetter(runeValue) || unicode.IsNumber(runeValue)) {
+			return errors.New("Only letters, numbers, underscores, slashes and hyphens allowed in environment variables")
+		}
+	}
 	return nil
 }
 
-func (s *stringSlice) Get() interface{} {
+// -- envSlice Value
+type envVariable struct {
+	Name  string
+	Value string
+}
+
+type envSlice []envVariable
+
+func (s *envSlice) Set(val string) error {
+	if !strings.Contains(val, "=") {
+		return errors.New("Environment variable format is 'ENVNAME=value'")
+	}
+	pair := strings.SplitN(val, "=", 2)
+	for _, item := range pair {
+		if err := allowedSymbolsOnly(item); err != nil {
+			return err
+		}
+	}
+	envVar := envVariable{Name: pair[0], Value: pair[1]}
+	*s = append(*s, envVar)
+	return nil
+}
+
+func (s *envSlice) Get() interface{} {
 	return *s
 }
 
-func (s *stringSlice) String() string { return fmt.Sprintf("%v", *s) }
+func (s *envSlice) String() string { return fmt.Sprintf("%v", *s) }
 
-func (wf *WorkerFlags) envVars() *stringSlice {
-	var sameNamedFlags stringSlice
-	wf.Var(&sameNamedFlags, "e", "optional: specify environment variable for your code in format 'var=value'")
+func (wf *WorkerFlags) envVars() *envSlice {
+	var sameNamedFlags envSlice
+	wf.Var(&sameNamedFlags, "e", "optional: specify environment variable for your code in format 'ENVNAME=value'")
 	return &sameNamedFlags
 }
 

--- a/vendored/github.com/iron-io/iron_go3/worker/methods.go
+++ b/vendored/github.com/iron-io/iron_go3/worker/methods.go
@@ -71,18 +71,19 @@ type TaskInfo struct {
 type CodeSource map[string][]byte // map[pathInZip]code
 
 type Code struct {
-	Id             string `json:"id,omitempty"`
-	Name           string `json:"name"`
-	Runtime        string `json:"runtime"`
-	FileName       string `json:"file_name"`
-	Config         string `json:"config,omitempty"`
-	MaxConcurrency int    `json:"max_concurrency,omitempty"`
-	Retries        int    `json:"retries,omitempty"`
-	Stack          string `json:"stack"`
-	Image          string `json:"image"`
-	Command        string `json:"command"`
-	RetriesDelay   int    `json:"retries_delay,omitempty"` // seconds
-	Host           string `json:"host,omitempty"`          // PaaS router thing
+	Id             string            `json:"id,omitempty"`
+	Name           string            `json:"name"`
+	Runtime        string            `json:"runtime"`
+	FileName       string            `json:"file_name"`
+	Config         string            `json:"config,omitempty"`
+	MaxConcurrency int               `json:"max_concurrency,omitempty"`
+	Retries        int               `json:"retries,omitempty"`
+	Stack          string            `json:"stack"`
+	Image          string            `json:"image"`
+	Command        string            `json:"command"`
+	RetriesDelay   int               `json:"retries_delay,omitempty"` // seconds
+	Host           string            `json:"host,omitempty"`          // PaaS router thing
+	EnvVars        map[string]string `json:"env_vars"`
 }
 
 type CodeInfo struct {


### PR DESCRIPTION
Ability to define docker-style environment variables on code upload.
Sample format: `-e mascot=gopher -e lang=go`.