### PR TITLE
switching docs to show new (https) install URL and adding disclaimer to install docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ iron.json
 ironcli-*
 mytoken.txt
 /iron
+install

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ curl -f -sSL https://cli.iron.io/install -O
 sh install
 ```
 
-### `curl | sh` as an Installation Method?
+#### `curl | sh` as an Installation Method?
 
 We'd like to explain why we're telling you to `curl | sh` to install this software.
 The script at https://cli.iron.io/install has some relatively simple logic to download the

--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ Go version of the Iron.io command line tools.
 
 `curl -sSL https://cli.iron.io/install | sh`
 
+If you're concerned about the [potential insecurity](http://curlpipesh.tumblr.com/)
+of using `curl | sh`, feel free to use a two-step version of our installation and examine our
+installation script:
+
+```bash
+curl -f -sSL https://cli.iron.io/install -O
+sh install
+```
+
+### `curl | sh` as an Installation Method?
+
+We'd like to explain why we're telling you to `curl | sh` to install this software.
+The script at https://cli.iron.io/install has some relatively simple logic to download the
+right `ironcli` binary for your platform. When you run that script by piping the `curl` output
+into `sh`, you're trusting us that it's safe and won't harm your computer. We hope that you do!
+But if you don't please see the section just below this one on how to download and run the binary
+yourself without an install script.
+
 ## Download Yourself
 
 Grab the latest version for your system on the [Releases](https://github.com/iron-io/ironcli/releases) page.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Go version of the Iron.io command line tools.
 
 ## Quick and Easy (Recommended)
 
-`curl -sSL http://get.iron.io/cli | sh`
+`curl -sSL https://cli.iron.io/install | sh`
 
 ## Download Yourself
 

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,9 @@
 set -e
 #
 # This script is meant for quick & easy install via:
-#   'curl -sSL http://get.iron.io/cli | sh'
+#   'curl -sSL https://cli.iron.io/install | sh'
 # or:
-#   'wget -qO- http://get.iron.io/cli | sh'
+#   'wget -qO- https://cli.iron.io/install | sh'
 #
 
 # UPDATE RELEASE HERE AFTER A NEW VERSION IS RELEASED
@@ -94,4 +94,3 @@ cat >&2 <<'EOF'
 
 EOF
 exit 1
-


### PR DESCRIPTION
https://cli.iron.io/install is now up and accepts https requests (doesn't require them). this branch is only intended to replace the http install URL to an https one. it will still redirect for now, and future work may add installers, packages for packaging systems (brew, yum, etc...). see #42 to track that work.

cc/ @rdallman @treeder 