### PR TITLE
docker login would have been royally broken had this been deployed

### DIFF
--- a/cmd/docker/docker_login.go
+++ b/cmd/docker/docker_login.go
@@ -30,12 +30,12 @@ func NewDockerLogin(settings *common.Settings) *DockerLogin {
 		ArgsUsage: "[args]",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:        "e",
+				Name:        "email, e",
 				Usage:       "docker repo user email",
 				Destination: &dockerLogin.Email,
 			},
 			cli.StringFlag{
-				Name:        "p",
+				Name:        "password, p",
 				Usage:       "docker repo password",
 				Destination: &dockerLogin.Password,
 			},
@@ -45,7 +45,7 @@ func NewDockerLogin(settings *common.Settings) *DockerLogin {
 				Destination: &dockerLogin.ServerAddress,
 			},
 			cli.StringFlag{
-				Name:        "u",
+				Name:        "username, u",
 				Usage:       "docker repo user name",
 				Destination: &dockerLogin.Username,
 			},

--- a/cmd/docker/docker_login.go
+++ b/cmd/docker/docker_login.go
@@ -30,12 +30,12 @@ func NewDockerLogin(settings *common.Settings) *DockerLogin {
 		ArgsUsage: "[args]",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:        "email",
+				Name:        "e",
 				Usage:       "docker repo user email",
 				Destination: &dockerLogin.Email,
 			},
 			cli.StringFlag{
-				Name:        "password",
+				Name:        "p",
 				Usage:       "docker repo password",
 				Destination: &dockerLogin.Password,
 			},
@@ -45,7 +45,7 @@ func NewDockerLogin(settings *common.Settings) *DockerLogin {
 				Destination: &dockerLogin.ServerAddress,
 			},
 			cli.StringFlag{
-				Name:        "username",
+				Name:        "u",
 				Usage:       "docker repo user name",
 				Destination: &dockerLogin.Username,
 			},


### PR DESCRIPTION
docker login will not work without these fields like [this](https://github.com/iron-io/ironcli/blob/to-the-libs/commands.go#L99-L102) in json format. the flags were also [broken](https://github.com/iron-io/ironcli/blob/to-the-libs/flags.go#L29-L40) -- the package we're using doesn't support gnu short and long flags :( ? the docker login protocol is pretty hairy, but ironcli has seem to have been broken in many mysterious ways by this recent patch, making me want to revert the whole of it (why did we do it, anyway?). it's unacceptable to have breaking changes in the CLI now, I haven't tried very hard but it seems likely that there are more. I am somewhat ashamed that contributing this patch will actually support going further with the recent changes, but I'd rather not break things if for example this somehow gets released like earlier today.

this will forego the actual login check in the client, moving that to the server (it's also very restrictive here, only supporting v1). i doubt this will be deployed as tip before worker is updated, patched worker accordingly. at a minimum we need to change the json and flags with this patch.