### PR TITLE
Updated the returned url to hud e

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -80,7 +80,7 @@ func (bc *command) Config() error {
 		return errors.New("did not find token in any config files or env variables")
 	}
 
-	bc.hud_URL_str = `Check https://hud.iron.io/tq/projects/` + bc.wrkr.Settings.ProjectId + "/"
+	bc.hud_URL_str = `Check https://hud-e.iron.io/worker/projects/` + bc.wrkr.Settings.ProjectId + "/"
 
 	fmt.Println(LINES, `Configuring client`)
 


### PR DESCRIPTION
Currently, after uploading a worker, the cli gives you a url to see the worker. This link goes to the old version of the UI and therefore brings up a 404.

I updated the link to send you to hud-e