### PR TITLE
Omit sending to server 'unset' MaxConcurrency if flag isn't specified

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -751,8 +751,9 @@ func (u *RegisterCmd) Args() error {
 	if *u.retriesDelay != unset {
 		u.codes.RetriesDelay = u.retriesDelay
 	}
-
-	u.codes.MaxConcurrency = *u.maxConc
+	if *u.maxConc != unset {
+		u.codes.MaxConcurrency = *u.maxConc
+	}
 	u.codes.Config = *u.config
 	u.codes.DefaultPriority = *u.defaultPriority
 


### PR DESCRIPTION
Fixes MaxConcurrency inheritance from previous `Code` version.