### PR TITLE
Experimental support for synchronous tasks

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -162,6 +162,7 @@ type QueueCmd struct {
 	timeout           *int
 	delay             *int
 	wait              *bool
+	sync              *bool
 	cluster           *string
 	label             *string
 	encryptionKey     *string
@@ -306,6 +307,7 @@ func (q *QueueCmd) Flags(args ...string) error {
 	q.timeout = q.flags.timeout()
 	q.delay = q.flags.delay()
 	q.wait = q.flags.wait()
+	q.sync = q.flags.sync()
 	q.cluster = q.flags.cluster()
 	q.label = q.flags.label()
 	q.encryptionKey = q.flags.encryptionKey()
@@ -382,9 +384,18 @@ func (q *QueueCmd) Usage() {
 	q.flags.PrintDefaults()
 }
 
+func sleepBetweenRetries(previousDuration time.Duration) time.Duration {
+	if previousDuration >= 60*time.Second {
+		return previousDuration
+	}
+	return previousDuration + previousDuration
+}
+
 func (q *QueueCmd) Run() {
 	fmt.Println(LINES, "Queueing task '"+q.task.CodeName+"'")
-
+	if *q.sync {
+		q.task.Sync = true
+	}
 	tasks := make([]worker.Task, *q.n)
 	for i := 0; i < *q.n; i++ {
 		tasks[i] = q.task
@@ -400,7 +411,7 @@ func (q *QueueCmd) Run() {
 	fmt.Printf("%s Queued task with id='%s'\n", BLANKS, id)
 	fmt.Println(BLANKS, q.hud_URL_str+"tasks/"+id+INFO)
 
-	if *q.wait {
+	if *q.wait || *q.sync {
 		fmt.Println(LINES, yellow("Waiting for task to start running"))
 
 		done := make(chan struct{})
@@ -421,16 +432,27 @@ func (q *QueueCmd) Run() {
 			fmt.Fprintln(os.Stderr, "error running task:", ti.Msg)
 			return
 		}
+		// wait for log
+		end := time.After(15 * time.Second)
+		logFunc := q.wrkr.WaitForTaskLog
+		title := "log"
+		if q.task.Sync {
+			logFunc = q.wrkr.WaitForTaskOutLog
+			title = "stdout"
+		}
 
-		log, err := q.wrkr.TaskLog(id)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "error getting log:", err)
+		var log []byte
+		select {
+		case ironLog := <-logFunc(id):
+			log = ironLog
+		case <-end:
+			fmt.Printf("Task timed out to get task %s or the %s is empty %s", title, title, id)
 			return
 		}
 
 		// TODO print actual run time?
 		fmt.Println(LINES, green("Done"))
-		fmt.Println(LINES, "Printing Log:")
+		fmt.Printf(LINES+" Printing %s:\n", title)
 		fmt.Printf("%s", string(log))
 	}
 }

--- a/flags.go
+++ b/flags.go
@@ -75,6 +75,10 @@ func (wf *WorkerFlags) wait() *bool {
 	return wf.Bool("wait", false, "wait for task to complete and print log")
 }
 
+func (wf *WorkerFlags) sync() *bool {
+	return wf.Bool("sync", false, "run task synchronously and print stdout")
+}
+
 func (wf *WorkerFlags) maxConc() *int {
 	return wf.Int("max-concurrency", unset, "max workers to run in parallel. default is no limit")
 }


### PR DESCRIPTION
It's experimental support for tasks which acted as synchronous.

Usage example:

```
ironcli worker queue -sync iron/hello
```